### PR TITLE
make sqlite.text_factory setting configurable

### DIFF
--- a/bottle_sqlite.py
+++ b/bottle_sqlite.py
@@ -53,11 +53,12 @@ class SQLitePlugin(object):
     api = 2
 
     def __init__(self, dbfile=':memory:', autocommit=True, dictrows=True,
-                 keyword='db'):
+                 keyword='db', text_factory=unicode):
         self.dbfile = dbfile
         self.autocommit = autocommit
         self.dictrows = dictrows
         self.keyword = keyword
+        self.text_factory = text_factory
 
     def setup(self, app):
         ''' Make sure that other installed plugins don't affect the same
@@ -91,6 +92,7 @@ class SQLitePlugin(object):
         autocommit = g('autocommit', self.autocommit)
         dictrows = g('dictrows', self.dictrows)
         keyword = g('keyword', self.keyword)
+        text_factory = g('keyword', self.text_factory)
 
         # Test if the original callback accepts a 'db' keyword.
         # Ignore it if it does not need a database handle.
@@ -101,6 +103,8 @@ class SQLitePlugin(object):
         def wrapper(*args, **kwargs):
             # Connect to the database
             db = sqlite3.connect(dbfile)
+            # set text factory
+            db.text_factory = text_factory
             # This enables column access by name: row['column_name']
             if dictrows:
                 db.row_factory = sqlite3.Row


### PR DESCRIPTION
hi,

i was struggling with some unicode foobars in sqlite and it seems the bottle_sqlite module does not allow to set the sqlite text_factory setting, which defaults to unicode. Attached patch makes it possible to set the text_factory upon setting up the module

thanks
