### PR TITLE
Changed the call to inspect.getargspec() to call inspect.signature() …

### DIFF
--- a/bottle_sqlite.py
+++ b/bottle_sqlite.py
@@ -111,8 +111,8 @@ class SQLitePlugin(object):
 
         # Test if the original callback accepts a 'db' keyword.
         # Ignore it if it does not need a database handle.
-        argspec = inspect.getargspec(_callback)
-        if keyword not in argspec.args:
+        signature = inspect.signature(_callback)
+        if keyword not in signature.parameters:
             return callback
 
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
…because the getargspec() function was removed from the inspect module.

Without this, the library does not work with Python 3.11.