### PR TITLE
Make bottle_sqlite comptible with python 3.11

### DIFF
--- a/bottle_sqlite.py
+++ b/bottle_sqlite.py
@@ -111,7 +111,7 @@ class SQLitePlugin(object):
 
         # Test if the original callback accepts a 'db' keyword.
         # Ignore it if it does not need a database handle.
-        argspec = inspect.getargspec(_callback)
+        argspec = inspect.getfullargspec(_callback)
         if keyword not in argspec.args:
             return callback
 


### PR DESCRIPTION
Python 3.11 removed the function getargspec of the inspect module and suggests replacing it with getfullargspec.